### PR TITLE
Fixes bug in grinder

### DIFF
--- a/src/main/java/appeng/tile/grindstone/TileGrinder.java
+++ b/src/main/java/appeng/tile/grindstone/TileGrinder.java
@@ -112,9 +112,10 @@ public class TileGrinder extends AEBaseInvTile implements ICrankable
 				{
 					if( item.getCount() >= r.getInput().getCount() )
 					{
-						item.grow( -r.getInput().getCount() );
 						final ItemStack ais = item.copy();
 						ais.setCount( r.getInput().getCount() );
+
+						item.shrink( r.getInput().getCount() );
 
 						if( item.getCount() <= 0 )
 						{


### PR DESCRIPTION
This fixes the Grinder not working in case of an input
ItemStack with size equal to one.
The important bit here is the sequence of instructions.
With the <=1.10 representation of empty ItemStacks using null
the old ordering was fine. However, whenever an ItemStack gets
shrinked to zero, its internal Item gets replaced, thus you
have to make a copy before shrinking.

Additionally using ItemStack::shrink instead of grow with
negative value. I can't stand such things D: